### PR TITLE
Add support for OS/2 table

### DIFF
--- a/src/font.cpp
+++ b/src/font.cpp
@@ -642,6 +642,13 @@ bool Font::load_ttf_mem( const uint8_t *ttf ) {
     em_line_gap = ttf_i16( hhea + 8 );
 
     uint32_t num_hmtx = ttf_u16( hhea + 34 );
+
+    const uint8_t *os2 = find_table( ttf, "OS/2" );
+    if ( os2 ) {
+        em_ascent  = ttf_i16( os2 + 68 );
+        em_descent = ttf_i16( os2 + 70 );
+        em_line_gap = ttf_i16( os2 + 72 );
+    }
     
     float scale = 1.0f / em_ascent;
     ascent   = 1.0;


### PR DESCRIPTION
Hello!

First, great project! I've encountered an issue with some fonts. Specifically, some fonts don't have their ascent, descent and line_gap values stored in the hhea table but in the OS/2 table instead.

Quote from [https://www.w3.org/TR/CSS2/visudet.html#leading](url)

> Note. It is recommended that implementations that use OpenType or TrueType fonts use the metrics "sTypoAscender" and "sTypoDescender" from the font's OS/2 table for A and D (after scaling to the current element's font size). In the absence of these metrics, the "Ascent" and "Descent" metrics from the HHEA table should be used.

This change makes it so the OS/2 table will always be used if it is present.